### PR TITLE
feat: criação do componente ds-image-label

### DIFF
--- a/packages/design-system/components/image-label/__tests__/image-label.test.ts
+++ b/packages/design-system/components/image-label/__tests__/image-label.test.ts
@@ -1,0 +1,30 @@
+import { html, fixture, expect } from '@open-wc/testing'
+import ImageLabel from '../src/index'
+import '../src/index.js'
+
+describe('<ds-image-label/>', () => {
+  it('should render component with image and two labels', async () => {
+    const el = await fixture<ImageLabel>(
+      html` <ds-image-label
+        imageSrc="image-source"
+        primaryLabel="Nome do álbum"
+        secondaryLabel="Nome do artista"
+      />`
+    )
+    const image = el.shadowRoot?.querySelector('img')
+    expect(image).to.have.property('src', 'http://localhost:8000/image-source')
+    expect(image).to.have.property('alt', 'Nome do álbum')
+
+    const labels = el.shadowRoot?.querySelectorAll('span') || []
+    expect(labels[0]).to.have.trimmed.text('Nome do álbum')
+    expect(labels[1]).to.have.trimmed.text('Nome do artista')
+  })
+  it('should render component with width and height pre defined', async () => {
+    const el = await fixture<ImageLabel>(
+      html` <ds-image-label imageWidth="100" imageHeight="100" />`
+    )
+    const image = el.shadowRoot?.querySelector('img')
+    expect(image).to.have.property('width', 100)
+    expect(image).to.have.property('height', 100)
+  })
+})

--- a/packages/design-system/components/image-label/package.json
+++ b/packages/design-system/components/image-label/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "ds-image-label",
+  "version": "0.0.0",
+  "description": "Image plus labels web component.",
+  "main": "dist/src/index.js",
+  "scripts": {
+    "ds-build": "tsc",
+    "ds-build-watch": "tsc --watch"
+  },
+  "devDependencies": {
+    "typescript": "^4.1.3"
+  },
+  "dependencies": {
+    "lit-element": "^2.4.0"
+  },
+  "license": "MIT"
+}

--- a/packages/design-system/components/image-label/src/index.ts
+++ b/packages/design-system/components/image-label/src/index.ts
@@ -1,0 +1,52 @@
+import {
+  customElement,
+  html,
+  LitElement,
+  property,
+  TemplateResult
+} from 'lit-element'
+
+import styles, { dynamicStyles } from './styles'
+
+@customElement('ds-image-label')
+export default class ImageLabel extends LitElement {
+  @property()
+  imageSrc = ''
+
+  @property()
+  imageWidth = 200
+
+  @property()
+  imageHeight = 200
+
+  @property()
+  primaryLabel = ''
+
+  @property()
+  secondaryLabel = ''
+
+  static styles = styles
+  render(): TemplateResult {
+    return html`
+      <style>
+        ${dynamicStyles(this.imageWidth)}
+      </style>
+      <div class="image-label-container">
+        <img
+          src=${this.imageSrc}
+          alt=${this.primaryLabel}
+          width=${this.imageWidth}
+          height=${this.imageHeight}
+        />
+        <span class="primary-label">${this.primaryLabel}</span>
+        <span class="secondary-label">${this.secondaryLabel}</span>
+      </div>
+    `
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'ds-image-label': ImageLabel
+  }
+}

--- a/packages/design-system/components/image-label/src/styles.ts
+++ b/packages/design-system/components/image-label/src/styles.ts
@@ -1,0 +1,31 @@
+import { css, unsafeCSS, CSSResult } from 'lit-element'
+
+export const dynamicStyles = (imageWidth?: number): CSSResult => {
+  const imageWidthValue = unsafeCSS(imageWidth)
+
+  return css`
+    .image-label-container {
+      width: ${imageWidthValue}px;
+    }
+  `
+}
+
+export default css`
+  .image-label-container {
+    display: flex;
+    flex-direction: column;
+    font-family: var(--font-family);
+    font-size: var(--m-font-size);
+    gap: 10px;
+    overflow: hidden;
+    text-align: center;
+  }
+
+  .primary-label {
+    color: var(--white);
+  }
+
+  .secondary-label {
+    color: var(--gray-medium);
+  }
+`

--- a/packages/design-system/components/image-label/tsconfig.json
+++ b/packages/design-system/components/image-label/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../commons/tsconfig.base",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "./"
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
## O que causou o Pull Reguest?

Criação do web component `ds-image-label`, do Design System.

## Detalhes de implementação

- Criação do web component `ds-image-label`;
- Criação dos testes;