### PR TITLE
feat: criação do componente ds-image-icon

### DIFF
--- a/packages/design-system/components/image-icon/__tests__/image-icon.test.ts
+++ b/packages/design-system/components/image-icon/__tests__/image-icon.test.ts
@@ -1,0 +1,22 @@
+import { html, fixture, expect } from '@open-wc/testing'
+import ImageIcon from '../src/index'
+import '../src/index.js'
+
+describe('<ds-image-icon/>', () => {
+  it('should render component with image and two labels', async () => {
+    const el = await fixture<ImageIcon>(
+      html` <ds-image-icon imageSrc="image-source" imageAlt="image alt" />`
+    )
+    const image = el.shadowRoot?.querySelector('img')
+    expect(image).to.have.property('src', 'http://localhost:8000/image-source')
+    expect(image).to.have.property('alt', 'image alt')
+  })
+  it('should render component with width and height pre defined', async () => {
+    const el = await fixture<ImageIcon>(
+      html` <ds-image-icon imageWidth="100" imageHeight="100" />`
+    )
+    const image = el.shadowRoot?.querySelector('img')
+    expect(image).to.have.property('width', 100)
+    expect(image).to.have.property('height', 100)
+  })
+})

--- a/packages/design-system/components/image-icon/package.json
+++ b/packages/design-system/components/image-icon/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "ds-image-icon",
+  "version": "0.0.0",
+  "description": "Image icon web component.",
+  "main": "dist/src/index.js",
+  "scripts": {
+    "ds-build": "tsc",
+    "ds-build-watch": "tsc --watch"
+  },
+  "devDependencies": {
+    "typescript": "^4.1.3"
+  },
+  "dependencies": {
+    "lit-element": "^2.4.0"
+  },
+  "license": "MIT"
+}

--- a/packages/design-system/components/image-icon/src/index.ts
+++ b/packages/design-system/components/image-icon/src/index.ts
@@ -1,0 +1,39 @@
+import {
+  customElement,
+  html,
+  LitElement,
+  property,
+  TemplateResult
+} from 'lit-element'
+
+@customElement('ds-image-icon')
+export default class ImageIcon extends LitElement {
+  @property()
+  imageSrc = ''
+
+  @property()
+  imageWidth = 64
+
+  @property()
+  imageHeight = 64
+
+  @property()
+  imageAlt = ''
+
+  render(): TemplateResult {
+    return html`
+      <img
+        src=${this.imageSrc}
+        alt=${this.imageAlt}
+        width=${this.imageWidth}
+        height=${this.imageHeight}
+      />
+    `
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'ds-image-icon': ImageIcon
+  }
+}

--- a/packages/design-system/components/image-icon/tsconfig.json
+++ b/packages/design-system/components/image-icon/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../commons/tsconfig.base",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "./"
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
## O que causou o Pull Reguest?

Criação do web component `ds-image-icon`, do Design System.

## Detalhes de implementação

- Criação do web component `ds-image-icon`;
- Criação dos testes;