### PR TITLE
feat: criação do componente ds-button

### DIFF
--- a/packages/design-system/components/button/__tests__/button.test.ts
+++ b/packages/design-system/components/button/__tests__/button.test.ts
@@ -1,0 +1,28 @@
+import { html, fixture, expect, oneEvent } from '@open-wc/testing'
+import Button from '../src/index'
+import '../src/index.js'
+
+describe('<ds-button/>', () => {
+  it('renders the button with a left-arrow', async () => {
+    const el = await fixture<Button>(html`
+      <ds-button isReturnButton="true">Return button</ds-button>
+    `)
+    const arrow = el.shadowRoot?.querySelector('.arrow-left')
+    expect(arrow).to.exist
+  })
+  it('renders the button disabled', async () => {
+    const el = await fixture<Button>(html`
+      <ds-button disabled>Button disabled</ds-button>
+    `)
+    expect(el).to.have.attribute('disabled')
+  })
+  it('fires external click event', async () => {
+    const el = await fixture<Button>(html`
+      <ds-button @click="${() => 'void'}"> Button clicked </ds-button>
+    `)
+    setTimeout(() => el.click())
+
+    const e = await oneEvent(el, 'click')
+    expect(e).to.be.not.null
+  })
+})

--- a/packages/design-system/components/button/package.json
+++ b/packages/design-system/components/button/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "ds-button",
+  "version": "0.0.0",
+  "description": "Button web component.",
+  "main": "dist/src/index.js",
+  "scripts": {
+    "ds-build": "tsc",
+    "ds-build-watch": "tsc --watch"
+  },
+  "devDependencies": {
+    "typescript": "^4.1.3"
+  },
+  "dependencies": {
+    "lit-element": "^2.4.0",
+    "ds-utils": "^0.0.0"
+  },
+  "license": "MIT"
+}

--- a/packages/design-system/components/button/src/index.ts
+++ b/packages/design-system/components/button/src/index.ts
@@ -1,0 +1,39 @@
+import {
+  customElement,
+  html,
+  LitElement,
+  property,
+  TemplateResult
+} from 'lit-element'
+import { booleanConverter } from 'ds-utils'
+
+import styles from './styles'
+
+@customElement('ds-button')
+export default class Button extends LitElement {
+  @property({ type: Boolean, converter: booleanConverter })
+  isReturnButton = false
+
+  @property({ type: Boolean, converter: booleanConverter })
+  disabled = false
+
+  private _renderArrowLeft() {
+    if (this.isReturnButton) return html`<span class="arrow-left" />`
+  }
+
+  static styles = styles
+  render(): TemplateResult {
+    return html`
+      <button ?disabled=${this.disabled} class="button">
+        ${this._renderArrowLeft()}
+        <slot />
+      </button>
+    `
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'ds-button': Button
+  }
+}

--- a/packages/design-system/components/button/src/styles.ts
+++ b/packages/design-system/components/button/src/styles.ts
@@ -1,0 +1,37 @@
+import { css } from 'lit-element'
+
+export default css`
+  .button {
+    background: none;
+    border: none;
+    color: var(--white);
+    cursor: pointer;
+    font-family: var(--font-family);
+    font-size: var(--s-font-size);
+    outline: 0;
+    transition: all 0.25s ease;
+  }
+
+  .button:disabled {
+    color: var(--gray-medium);
+    cursor: not-allowed;
+  }
+
+  .button:not(:disabled):hover {
+    opacity: var(--hover-opacity);
+  }
+
+  .button[disabled] .arrow-left {
+    border-color: var(--gray-medium);
+  }
+
+  .arrow-left {
+    -webkit-transform: rotate(135deg);
+    border-color: var(--white);
+    border-style: solid;
+    border-width: 0 2px 2px 0;
+    display: inline-block;
+    padding: 3px;
+    transform: rotate(135deg);
+  }
+`

--- a/packages/design-system/components/button/tsconfig.json
+++ b/packages/design-system/components/button/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../commons/tsconfig.base",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "./"
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
## O que causou o Pull Reguest?

Criação do web component `ds-button`, do Design System.

## Detalhes de implementação

- Criação do web component `ds-button`;
- Criação dos testes;
- Correção de testes no `ds-image-icon`;